### PR TITLE
Use explicit #to_s to render attribute in form

### DIFF
--- a/lib/godmin/tags/helper.rb
+++ b/lib/godmin/tags/helper.rb
@@ -2,7 +2,8 @@ module Godmin
   module Tags
     module Helper
       def tags_field(attribute, options = {})
-        text_field(attribute, options.deep_merge(data: { behavior: "tagger" }))
+        defaults = { value: object.send(attribute).to_s, data: { behavior: "tagger" } }
+        text_field(attribute, defaults.deep_merge(options))
       end
     end
   end


### PR DESCRIPTION
Since Rails 4.2 html_safe is not used when outputting the attribute in
a text_field which in turn not runs #to_s on it anymore. Because of
this, Rails ends up running join(' ') on the attributes, if they are
arrays which is no good. Using an explicit #to_s makes Arrays render as
comma separated values like before.

This also reversed the options and defaults to make them overrideable. It seems reasonable :)

More info:
https://github.com/rails/rails/commit/19af434840802ca0feb39253241917286467a86e
And:
https://github.com/rails/rails/issues/20814
